### PR TITLE
Adding Engines of Fury Token BSC-zkEVM

### DIFF
--- a/squid/immutable_zkevm_token_list.json
+++ b/squid/immutable_zkevm_token_list.json
@@ -304,5 +304,23 @@
         "decimals": 18,
         "logoURI": "https://dantegames.com/icons/DanteToken.svg",
         "coingeckoId": "dante-games"
+    },
+    {
+        "chainId": "13371",
+        "address": "0xD46B5Ab42A96D873F4563925323EEF5F59b11E02",
+        "name": "Engines of Fury Token",
+        "symbol": "FURY",
+        "decimals": 18,
+        "logoURI": "https://files.eof.gg/eof_logo_black_600.png",
+        "coingeckoId": "engines-of-fury"
+    },
+    {
+        "chainId": "56",
+        "address": "0x0203D275D2A65030889aF45ed91D472be3948B92",
+        "name": "Engines of Fury Token",
+        "symbol": "FURY",
+        "decimals": 18,
+        "logoURI": "https://files.eof.gg/eof_logo_black_600.png",
+        "coingeckoId": "engines-of-fury"
     }
 ]


### PR DESCRIPTION
Adding the Engines of Fury token to the canonical list. Intention is to have this show on the Squid UI.

This token was mapped via Axelar ITS.

It originates on Binance Smart Chain here: https://bscscan.com/address/0x0203d275d2a65030889af45ed91d472be3948b92

Here is the address on Immutable zkEVM: https://explorer.immutable.com/address/0xD46B5Ab42A96D873F4563925323EEF5F59b11E02?tab=read_write_proxy

Have confirmed the CoinGecko ID as well: https://www.coingecko.com/en/coins/engines-of-fury