### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global owner
+@immutable/rollups
+
+# Github actions
+.github @immutable/rollups  @immutable/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owner
-@immutable/rollups
+* @immutable/rollups
 
 # Github actions
 .github @immutable/rollups  @immutable/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @immutable/rollups
 
 # Github actions
-.github @immutable/rollups  @immutable/security
+/.github/ @immutable/rollups  @immutable/security


### PR DESCRIPTION
Add CODEOWNERS file. The file makes the rollups team responsible for the repo in general and the rollups and the security teams responsible for the github actions.